### PR TITLE
Fix dead link for cpplint.py

### DIFF
--- a/README.md
+++ b/README.md
@@ -12,7 +12,7 @@ The expected behavious is that people just format the code fragment by first sel
 
 There are many C/C++ code format tools such as "[astyle](http://astyle.sourceforge.net/)" but currently **"[clang-format](http://clang.llvm.org/docs/ClangFormat.html)"** is my favorite. It has several pre-defined styles and is highly configurable.
 
-**[cpplint.py](http://google-styleguide.googlecode.com/svn/trunk/cppguide.html#cpplint)** is a C++ coding style checker provided by google. It can be used to check the C++ code against the [Google C++ coding style](http://google-styleguide.googlecode.com/svn/trunk/cppguide.html). It can detect many style errors and maintain the consistency of coding style.
+**[cpplint.py](https://google.github.io/styleguide/cppguide.html#cpplint)** is a C++ coding style checker provided by google. It can be used to check the C++ code against the [Google C++ coding style](http://google-styleguide.googlecode.com/svn/trunk/cppguide.html). It can detect many style errors and maintain the consistency of coding style.
 
 ## Requirement
     cpplint.py     https://google.github.io/styleguide/cppguide.html#cpplint


### PR DESCRIPTION
googlecode.com is closed -> use the same link as in the "Requirement" section.